### PR TITLE
Fixed broken links in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,15 @@ For those unaware, the Grawlix CMS is a tool that helps comic artist publish and
 The Grawlix CMS requires a web host with PHP5 and MySQL. You’ll need a database on the host before you install the system — check your host’s control panel for details. You will also need a code editor like [Sublime Text](https://www.sublimetext.com/), [Atom](https://atom.io/), or [Notepad++](https://notepad-plus-plus.org/), and an FTP app like [FileZilla](https://filezilla-project.org/) or [Transmit](https://panic.com/transmit/) for easy transfer of your files to your server. You may also use your webhost's built in FTP or code editing tools.
 
 <ul>
-  <li><a href="http://www.getgrawlix.com/docs/1/requirements">Learn more about the requirements</a>.</li>
+  <li><a href="http://web.archive.org/web/20171012235043/http://www.getgrawlix.com/docs/1/requirements">Learn more about the requirements</a>.</li>
   <li><a href="http://www.thedaemoschronicles.com/grawlix-cms-setup-walkthrough/">New to FTP and web hosting?</a> Check out our easy to follow walkthrough on installing the Grawlix CMS by Jordan Rodriguez</li>
-<li>Run into a bug? <a href="http://www.grawlixdevblog.com/bugs-report/">Report it</a>.</li>
+<li>Run into a bug? <a href="https://github.com/GrawlixCMSRevival/OfficialGrawlixCMSRevival/issues/new">Report it</a>.</li>
 </ul>
 
 # Installating the Grawlix CMS for the first time?
 <ul>
-  <li>1. Everything you need to know to install and run the Grawlix CMS can be found <a href="http://www.thedaemoschronicles.com/grawlix-cms-setup-walkthrough/">here</a>.</li>
+  <li>1. Everything you need to know to install and run the Grawlix CMS can be found <a href="http://web.archive.org/web/20180323091430/http://www.thedaemoschronicles.com/grawlix-cms-setup-walkthrough/">here</a>.</li>
+  <li> Troubleshooting help can be found <a href="http://www.thedaemoschronicles.com/grawlix-cms-setup-walkthrough/">here</a>.</li>
   <li>2. Download the latest version from the repo to get started.</li>
   </ul>
 
@@ -31,8 +32,8 @@ Among other changes and fixes, versions 1.3 and 1.4 make significant changes to 
 
 # More info & support
 <ul>
- <li> <a href="http://www.getgrawlix.com/docs">Read the docs</a>.</li>
- <li><a href="http://www.grawlixdevblog.com/">Follow the devblog</a>.</li>
+ <li> <a href="http://web.archive.org/web/20181214144117/http://www.getgrawlix.com/docs">Read the docs</a>.</li>
+ <li><a href="http://web.archive.org/web/20180827105248/http://www.grawlixdevblog.com/">Follow the devblog</a>.</li>
 </ul>
 
 — Grawlix CMS Revival Team


### PR DESCRIPTION
The links to getgrawlix.com and grawlixdevblog.com point to pages that
no longer exist. Most of them have been replaced with links to the most recent
valid copies hosted by the Internet Archive's Wayback Machine. The link
to track issues has been changed from the grawlixdevblog bug report form
to point to the GitHub issue tracker. 

This should resolve the issue at https://github.com/GrawlixCMSRevival/OfficialGrawlixCMSRevival/issues/1.